### PR TITLE
Update benchmark_gpu_queue.sh

### DIFF
--- a/script/bash/benchmark_gpu_queue.sh
+++ b/script/bash/benchmark_gpu_queue.sh
@@ -3,11 +3,11 @@
 # Perform a quick benchmark on all the nodes on GPU queue
 # UNCOMMENT THIS WHILE DEBUGGING: set -x
 
-PREFIX=gpu
+PREFIX="gpu"
 START=2
 END=48
 
-LOGFILE_PREFIX=benchmark
+LOGFILE_PREFIX="benchmark"
 NORMAL_TIME=230
 
 for i in `seq -f "%03g" ${START} ${END}`
@@ -15,7 +15,7 @@ do
   CPU_UTIL=`ssh gpu$i top -bn 2 -d 0.01 | grep 'Cpu' | tail -n 1 \
     | gawk '{print $2+$4+$6}'`
   if [ `echo "${CPU_UTIL} < 75.0" | bc` -eq 1 ]; then
-    local LOGFILE_NAME=${LOGFILE_PREFIX}_gpu$i.log
+    LOGFILE_NAME=${LOGFILE_PREFIX}_gpu$i.log
     echo "running on gpu queue with machine gpu$i" > ${LOGFILE_NAME}
     ssh gpu$i sysbench --test=cpu --cpu-max-prime=20000 \
       --num_threads=1 run >> ${LOGFILE_NAME} &


### PR DESCRIPTION
Removed the "local" in front of the LOGFILE_NAME variable. This causes errors when running the script. Also, added quotations around the PREFIX and LOGFILE_PREFIX variable definitions since they are strings.